### PR TITLE
POC: add discovery of PostgreSQL databases and push them as entities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.opensource.zalan.do/stups/python:3.5.2-38
 
-RUN apt-get update && apt-get install -y python3-dev libffi-dev libssl-dev
+RUN apt-get update && apt-get install -y python3-dev libffi-dev libssl-dev libpq-dev
 
 COPY . /agent
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.12
 scm-source>=1.0.9
 stups-tokens>=1.0.18
 zmon-cli>=1.0.57
+psycopg2

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -4,6 +4,7 @@
 
 import os
 import logging
+import psycopg2
 
 from . import kube
 
@@ -16,6 +17,7 @@ NODE_TYPE = 'kube_node'
 REPLICASET_TYPE = 'kube_replicaset'
 STATEFULSET_TYPE = 'kube_statefulset'
 DAEMONSET_TYPE = 'kube_daemonset'
+POSTGRESDB_TYPE = 'postgresql_database'
 
 INSTANCE_TYPE_LABEL = 'beta.kubernetes.io/instance-type'
 
@@ -37,6 +39,9 @@ class Discovery:
         self.namespace = os.environ.get('ZMON_AGENT_KUBERNETES_NAMESPACE')
         self.cluster_id = os.environ.get('ZMON_AGENT_KUBERNETES_CLUSTER_ID')
         self.alias = os.environ.get('ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS', '')
+
+        self.postgres_user = os.environ.get('ZMON_AGENT_POSTGRES_USER')
+        self.postgres_pass = os.environ.get('ZMON_AGENT_POSTGRES_PASS')
 
         if not self.cluster_id:
             raise RuntimeError('Cannot determine cluster ID. Please set env variable ZMON_AGENT_KUBERNETES_CLUSTER_ID')
@@ -81,10 +86,14 @@ class Discovery:
             self.kube_client, self.cluster_id, self.alias, self.region, self.infrastructure_account, namespace=self.namespace)
         statefulset_entities = get_cluster_statefulsets(
             self.kube_client, self.cluster_id, self.alias, self.region, self.infrastructure_account, namespace=self.namespace)
+        postgresdb_entities = get_cluster_postgresdbs(
+            self.kube_client, self.cluster_id, self.alias, self.region, self.infrastructure_account,
+            self.postgres_user, self.postgres_pass,
+            namespace=self.namespace)
 
         all_current_entities = (
             pod_entities + node_entities + service_entities + replicaset_entities + daemonset_entities +
-            statefulset_entities
+            statefulset_entities + postgresdb_entities
         )
 
         return all_current_entities
@@ -398,5 +407,62 @@ def get_cluster_daemonsets(kube_client, cluster_id, alias, region, infrastructur
         entity = add_labels_to_entity(entity, obj['metadata'].get('annotations', {}))
 
         entities.append(entity)
+
+    return entities
+
+
+def list_postgres_databases(*args, **kwargs):
+    conn = psycopg2.connect(*args, **kwargs)
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT datname
+          FROM pg_database
+         WHERE datname NOT IN('postgres', 'template0', 'template1')
+    """)
+    return [row[0] for row in cur.fetchall()]
+
+
+def get_cluster_postgresdbs(kube_client, cluster_id, alias, region, infrastructure_account,
+                            postgres_user, postgres_pass,
+                            namespace=None):
+    entities = []
+
+    services = get_all(kube_client, kube_client.get_services, namespace)
+
+    for service in services:
+        obj = service.obj
+
+        # TODO: filter in the API call
+        labels = obj['metadata'].get('labels', {})
+        if labels.get('application') != 'spilo':
+            continue
+
+        service_namespace = obj['metadata']['namespace']
+        service_dns_name = '{}.{}.svc.cluster.local'.format(service.name, service_namespace)
+        service_port = obj['spec']['ports'][0]['port']  # Assume the first port is the one we need.
+
+        dbnames = list_postgres_databases(host=service_dns_name,
+                                          port=service_port,
+                                          user=postgres_user,
+                                          password=postgres_pass,
+                                          dbname='postgres')
+        for db in dbnames:
+            entity = {
+                'id': 'postgresdb-{}-{}-{}[{}]'.format(db, service.name, service.namespace, cluster_id),
+                'type': POSTGRESDB_TYPE,
+                'kube_cluster': cluster_id,
+                'alias': alias,
+                'created_by': AGENT_TYPE,
+                'infrastructure_account': infrastructure_account,
+                'region': region,
+
+                'postgresql_cluster': service.name,
+                'database_name': db,
+                'shards': {
+                    db: '{}:{}/{}'.format(service_dns_name, service_port, db)
+                }
+            }
+
+            entities.append(entity)
 
     return entities

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -42,6 +42,8 @@ class Discovery:
 
         self.postgres_user = os.environ.get('ZMON_AGENT_POSTGRES_USER')
         self.postgres_pass = os.environ.get('ZMON_AGENT_POSTGRES_PASS')
+        if not (self.postgres_user and self.postgres_pass):
+            logger.warning('No credentials provided for PostgreSQL database discovery!')
 
         if not self.cluster_id:
             raise RuntimeError('Cannot determine cluster ID. Please set env variable ZMON_AGENT_KUBERNETES_CLUSTER_ID')
@@ -425,6 +427,9 @@ def list_postgres_databases(*args, **kwargs):
 def get_cluster_postgresdbs(kube_client, cluster_id, alias, region, infrastructure_account,
                             postgres_user, postgres_pass,
                             namespace=None):
+    if not (postgres_user and postgres_pass):
+        return []
+
     entities = []
 
     services = get_all(kube_client, kube_client.get_services, namespace)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -463,7 +463,7 @@ def get_cluster_postgresdbs(kube_client, cluster_id, alias, region, infrastructu
                                           sslmode='require')
         for db in dbnames:
             entity = {
-                'id': 'postgresdb-{}-{}-{}[{}]'.format(db, service.name, service.namespace, cluster_id),
+                'id': '{}-{}-{}[{}]'.format(db, service.name, service.namespace, cluster_id),
                 'type': POSTGRESDB_TYPE,
                 'kube_cluster': cluster_id,
                 'alias': alias,


### PR DESCRIPTION
We take all services with label application=spilo and try to connect to the
database cluster using .svc.cluster.local DNS name.

We assume that all Spilo clusters have the same user and password configured
with wich we can connect and list the database names.  The username and the
password need to be provided in two new environment variables, namely:
ZMON_AGENT_POSTGRES_{USER,PASS}.  We assume that we can reuse pre-existing
user that is configured for ZMON worker already.

For every non-system database we create a separate entity of type
'postgresql_database' and configure the 'shards' property so that ZMON checks
can use `sql()` function without further parameters to access the database.