### PR TITLE
Add postgresql_cluster_member entity type

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -118,7 +118,7 @@ class Discovery:
 
         all_current_entities = (
             pod_entities + node_entities + service_entities + replicaset_entities + daemonset_entities +
-            ingress_entities + statefulset_entities + postgresql_cluster_entities + postgresql_cluster_member_entities + 
+            ingress_entities + statefulset_entities + postgresql_cluster_entities + postgresql_cluster_member_entities +
             postgresql_database_entities
         )
 

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -20,6 +20,7 @@ STATEFULSET_TYPE = 'kube_statefulset'
 DAEMONSET_TYPE = 'kube_daemonset'
 
 POSTGRESQL_CLUSTER_TYPE = 'postgresql_cluster'
+POSTGRESQL_CLUSTER_MEMBER_TYPE = 'postgresql_cluster_member'
 POSTGRESQL_DATABASE_TYPE = 'postgresql_database'
 POSTGRESQL_DEFAULT_PORT = 5432
 
@@ -98,13 +99,16 @@ class Discovery:
         postgresql_cluster_entities = get_postgresql_clusters(
             self.kube_client, self.cluster_id, self.alias, self.region, self.infrastructure_account,
             namespace=self.namespace)
+        postgresql_cluster_member_entities = get_postgresql_cluster_members(
+            self.kube_client, self.cluster_id, self.alias, self.region, self.infrastructure_account,
+            namespace=self.namespace)
         postgresql_database_entities = get_postgresql_databases(
             postgresql_cluster_entities, self.cluster_id, self.alias, self.region, self.infrastructure_account,
             self.postgres_user, self.postgres_pass)
 
         all_current_entities = (
-            pod_entities + node_entities + service_entities + replicaset_entities + daemonset_entities +
-            statefulset_entities + postgresql_cluster_entities + postgresql_database_entities
+            pod_entities + node_entities + service_entities + replicaset_entities + daemonset_entities + statefulset_entities +
+            postgresql_cluster_entities + postgresql_cluster_member_entities + postgresql_database_entities
         )
 
         return all_current_entities
@@ -457,7 +461,7 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, region, infrastructu
         service_dns_name = '{}.{}.svc.cluster.local'.format(service.name, service_namespace)
 
         entity = {
-            'id': '{}-{}[{}]'.format(service.name, service.namespace, cluster_id),
+            'id': 'pg-{}[{}]'.format(service.name, cluster_id),
             'type': POSTGRESQL_CLUSTER_TYPE,
             'kube_cluster': cluster_id,
             'alias': alias,
@@ -469,6 +473,42 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, region, infrastructu
             'shards': {
                 'postgres': '{}:{}/postgres'.format(service_dns_name, POSTGRESQL_DEFAULT_PORT)
             }
+        }
+
+        entities.append(entity)
+
+    return entities
+
+
+def get_postgresql_cluster_members(kube_client, cluster_id, alias, region, infrastructure_account,
+                                   namespace=None):
+    entities = []
+
+    pods = get_all(kube_client, kube_client.get_pods, namespace)
+
+    for pod in pods:
+        obj = pod.obj
+
+        # TODO: filter in the API call
+        labels = obj['metadata'].get('labels', {})
+        if labels.get('application') != 'spilo' or labels.get('version') is None:
+            continue
+
+        pod_number = pod.name.split('-')[-1]
+        pod_namespace = obj['metadata']['namespace']
+        service_dns_name = '{}.{}.svc.cluster.local'.format(labels['version'], pod_namespace)
+
+        entity = {
+            'id': 'pg-{}-{}[{}]'.format(service_dns_name, pod_number, cluster_id),
+            'type': POSTGRESQL_CLUSTER_MEMBER_TYPE,
+            'kube_cluster': cluster_id,
+            'alias': alias,
+            'created_by': AGENT_TYPE,
+            'infrastructure_account': infrastructure_account,
+            'region': region,
+
+            'dnsname': service_dns_name,
+            'pod': pod.name
         }
 
         entities.append(entity)


### PR DESCRIPTION
For consistent naming, remove namespace from postgresql_cluster entity id,
since it is already part of service DNS name and add a pg- prefix, e.g:
pg-mypostgres.default.svc.cluster.local

The cluster member entities are created from pods of application 'spilo' with
the same 'version' label as the service used to create cluster entity has.