### PR TITLE
Database replica discovery

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -111,7 +111,7 @@ class Discovery:
 
         postgresql_cluster_entities, pce = itertools.tee(get_postgresql_clusters(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
-            self.hosted_zone_format_string, namespace=self.namespace)
+            self.hosted_zone_format_string, namespace=self.namespace))
         postgresql_cluster_member_entities = get_postgresql_cluster_members(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
             self.hosted_zone_format_string, namespace=self.namespace)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -530,11 +530,13 @@ def get_postgresql_clusters(statefulsets, kube_client, cluster_id, alias, enviro
         service_dns_name = '{}.{}.svc.cluster.local'.format(service.name, service_namespace)
 
         statefulset_error = ''
+        ss = {}
         statefulset = [ss for ss in ssets if ss['version'] == version]
+
         if not statefulset:  # can happen when the replica count is 0.In this case we don't have a running cluster.
             statefulset_error = 'There is no statefulset attached'
-
-        ss = statefulset[0]
+        else:
+            ss = statefulset[0]
 
         yield {
             'id': 'pg-{}[{}]'.format(service.name, cluster_id),
@@ -552,8 +554,8 @@ def get_postgresql_clusters(statefulsets, kube_client, cluster_id, alias, enviro
             'shards': {
                 'postgres': '{}:{}/postgres'.format(service_dns_name, POSTGRESQL_DEFAULT_PORT)
             },
-            'expected_replica_count': ss['replicas'],
-            'current_replica_count': ss['actual_replicas'],
+            'expected_replica_count': ss.get('replicas', ''),
+            'current_replica_count': ss.get('actual_replicas', ''),
             'statefulset_error': statefulset_error,
             'deeplink1': '{}/#/status/{}'.format(hosted_zone.format('pgui', alias), version),
             'icon1': 'fa-server',

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -25,6 +25,7 @@ INGRESS_TYPE = 'kube_ingress'
 POSTGRESQL_CLUSTER_TYPE = 'postgresql_cluster'
 POSTGRESQL_CLUSTER_MEMBER_TYPE = 'postgresql_cluster_member'
 POSTGRESQL_DATABASE_TYPE = 'postgresql_database'
+POSTGRESQL_DATABASE_REPLICA_TYPE = 'postgresql_database_replica'
 POSTGRESQL_DEFAULT_PORT = 5432
 POSTGRESQL_CONNECT_TIMEOUT = os.environ.get('ZMON_AGENT_POSTGRESQL_CONNECT_TIMEOUT', 2)
 
@@ -101,17 +102,17 @@ class Discovery:
         daemonset_entities = get_cluster_daemonsets(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
             namespace=self.namespace)
-        statefulset_entities = get_cluster_statefulsets(
+        statefulset_entities, sse = itertools.tee(get_cluster_statefulsets(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
-            namespace=self.namespace)
+            namespace=self.namespace))
 
         ingress_entities = get_cluster_ingresses(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
             namespace=self.namespace)
 
         postgresql_cluster_entities, pce = itertools.tee(get_postgresql_clusters(
-            self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
-            self.hosted_zone_format_string, namespace=self.namespace))
+            sse, self.kube_client, self.cluster_id, self.alias, self.environment, self.region,
+            self.infrastructure_account, self.hosted_zone_format_string, namespace=self.namespace))
         postgresql_cluster_member_entities = get_postgresql_cluster_members(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
             self.hosted_zone_format_string, namespace=self.namespace)
@@ -414,6 +415,8 @@ def get_cluster_statefulsets(kube_client, cluster_id, alias, environment, region
 
             'replicas': obj['spec'].get('replicas'),
             'replicas_status': obj['status'].get('replicas'),
+            'actual_replicas': obj['status'].get('readyReplicas'),
+            'version': obj['metadata']['labels']['version']
         }
 
         entity.update(entity_labels(obj, 'labels', 'annotations'))
@@ -503,8 +506,10 @@ def list_postgres_databases(*args, **kwargs):
         return []
 
 
-def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region, infrastructure_account,
+def get_postgresql_clusters(statefulsets, kube_client, cluster_id, alias, environment, region, infrastructure_account,
                             hosted_zone, namespace=None):
+
+    ssets = [ss for ss in statefulsets]
 
     # TODO in theory clusters should be discovered using CRDs
     services = get_all(kube_client, kube_client.get_services, namespace)
@@ -512,19 +517,23 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
     for service in services:
         obj = service.obj
 
-        # TODO: filter in the API call
         labels = obj['metadata'].get('labels', {})
-        if labels.get('application') != 'spilo':
+        version = labels.get('version')
+
+        # we skip non-Spilos and replica services
+        if labels.get('application') != 'spilo' or labels.get('spilo-role') == 'replica':
             continue
 
         service_namespace = obj['metadata']['namespace']
         service_dns_name = '{}.{}.svc.cluster.local'.format(service.name, service_namespace)
 
-        # for master we do not use selector at all
-        is_replica = True if obj["spec"].get("selector") else False
+        statefulset = [ss for ss in ssets if ss['version'] == version]
+        if not statefulset:  # can happen when the replica count is 0.In this case we don't have a running cluster.
+            continue
+
+        ss = statefulset[0]
 
         yield {
-            # service.name contains -repl for replica service
             'id': 'pg-{}[{}]'.format(service.name, cluster_id),
             'type': POSTGRESQL_CLUSTER_TYPE,
             'kube_cluster': cluster_id,
@@ -533,17 +542,18 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
             'created_by': AGENT_TYPE,
             'infrastructure_account': infrastructure_account,
             'region': region,
-            'spilo_cluster': labels.get('version'),
-            'spilo_role': "replica" if is_replica else "master",
+            'spilo_cluster': version,
             'application': "spilo",
-            'version': labels.get('version'),
+            'version': version,
             'dnsname': service_dns_name,
             'shards': {
                 'postgres': '{}:{}/postgres'.format(service_dns_name, POSTGRESQL_DEFAULT_PORT)
             },
-            'deeplink1': '{}/#/status/{}'.format(hosted_zone.format('pgui', alias), labels.get('version')),
+            'expected_replica_count': ss['replicas'],
+            'current_replica_count': ss['actual_replicas'],
+            'deeplink1': '{}/#/status/{}'.format(hosted_zone.format('pgui', alias), version),
             'icon1': 'fa-server',
-            'deeplink2': '{}/#/clusters/{}'.format(hosted_zone.format('pgview', alias), labels.get('version')),
+            'deeplink2': '{}/#/clusters/{}'.format(hosted_zone.format('pgview', alias), version),
             'icon2': 'fa-line-chart'
         }
 
@@ -637,5 +647,27 @@ def get_postgresql_databases(postgresql_clusters, cluster_id, alias, environment
                 'database_name': db,
                 'shards': {
                     db: '{}:{}/{}'.format(pgcluster['dnsname'], POSTGRESQL_DEFAULT_PORT, db)
-                }
+                },
+                'role': 'master'
             }
+
+            if pgcluster['expected_replica_count'] > 1:  # the first k8s replica is the master itself
+                name_parts = pgcluster['dnsname'].split('.')
+                repl_dnsname = '.'.join([name_parts[0] + '-repl'] + name_parts[1:])
+                yield {
+                    'id': '{}-repl-{}'.format(db, pgcluster['id']),
+                    'type': POSTGRESQL_DATABASE_REPLICA_TYPE,
+                    'kube_cluster': cluster_id,
+                    'alias': alias,
+                    'environment': environment,
+                    'created_by': AGENT_TYPE,
+                    'infrastructure_account': infrastructure_account,
+                    'region': region,
+
+                    'postgresql_cluster': pgcluster['id'],
+                    'database_name': db,
+                    'shards': {
+                        db: '{}:{}/{}'.format(repl_dnsname, POSTGRESQL_DEFAULT_PORT, db)
+                    },
+                    'role': 'replica'
+                }

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -109,14 +109,14 @@ class Discovery:
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
             namespace=self.namespace)
 
-        postgresql_cluster_entities = get_postgresql_clusters(
+        postgresql_cluster_entities, pce = itertools.tee(get_postgresql_clusters(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
-            namespace=self.namespace)
+            namespace=self.namespace))
         postgresql_cluster_member_entities = get_postgresql_cluster_members(
             self.kube_client, self.cluster_id, self.alias, self.environment, self.region, self.infrastructure_account,
             namespace=self.namespace)
         postgresql_database_entities = get_postgresql_databases(
-            postgresql_cluster_entities, self.cluster_id, self.alias, self.environment, self.region,
+            pce, self.cluster_id, self.alias, self.environment, self.region,
             self.infrastructure_account, self.postgres_user, self.postgres_pass)
 
         return list(itertools.chain(
@@ -486,8 +486,6 @@ def get_cluster_ingresses(kube_client, cluster_id, alias, environment, region, i
 # POSTGRESQL   | TODO: move to separate discovery                                                                      #
 ########################################################################################################################
 def list_postgres_databases(*args, **kwargs):
-    logger.info("Trying to list DBs on host: {}".format(kwargs['host']))
-
     try:
         kwargs.update({'connect_timeout': POSTGRESQL_CONNECT_TIMEOUT})
 
@@ -501,7 +499,7 @@ def list_postgres_databases(*args, **kwargs):
         """)
         return [row[0] for row in cur.fetchall()]
     except Exception:
-        logger.exception("Failed to list DBs!")
+        logger.exception("Failed to list DBs on %s", kwargs.get('host', '{no host specified}'))
         return []
 
 

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -555,8 +555,8 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
             'shards': {
                 'postgres': '{}:{}/postgres'.format(service_dns_name, POSTGRESQL_DEFAULT_PORT)
             },
-            'expected_replica_count': ss.get('replicas', ''),
-            'current_replica_count': ss.get('actual_replicas', ''),
+            'expected_replica_count': ss.get('replicas', 0),
+            'current_replica_count': ss.get('actual_replicas', 0),
             'statefulset_error': statefulset_error,
             'deeplink1': '{}/#/status/{}'.format(hosted_zone.format('pgui', alias), version),
             'icon1': 'fa-server',

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -527,9 +527,10 @@ def get_postgresql_clusters(statefulsets, kube_client, cluster_id, alias, enviro
         service_namespace = obj['metadata']['namespace']
         service_dns_name = '{}.{}.svc.cluster.local'.format(service.name, service_namespace)
 
+        statefulset_error = ''
         statefulset = [ss for ss in ssets if ss['version'] == version]
         if not statefulset:  # can happen when the replica count is 0.In this case we don't have a running cluster.
-            continue
+            statefulset_error = 'There is no statefulset attached'
 
         ss = statefulset[0]
 
@@ -551,6 +552,7 @@ def get_postgresql_clusters(statefulsets, kube_client, cluster_id, alias, enviro
             },
             'expected_replica_count': ss['replicas'],
             'current_replica_count': ss['actual_replicas'],
+            'statefulset_error': statefulset_error,
             'deeplink1': '{}/#/status/{}'.format(hosted_zone.format('pgui', alias), version),
             'icon1': 'fa-server',
             'deeplink2': '{}/#/clusters/{}'.format(hosted_zone.format('pgview', alias), version),
@@ -642,7 +644,7 @@ def get_postgresql_databases(postgresql_clusters, cluster_id, alias, environment
                 'created_by': AGENT_TYPE,
                 'infrastructure_account': infrastructure_account,
                 'region': region,
-
+                'version': pgcluster['version'],
                 'postgresql_cluster': pgcluster['id'],
                 'database_name': db,
                 'shards': {
@@ -663,7 +665,7 @@ def get_postgresql_databases(postgresql_clusters, cluster_id, alias, environment
                     'created_by': AGENT_TYPE,
                     'infrastructure_account': infrastructure_account,
                     'region': region,
-
+                    'version': pgcluster['version'],
                     'postgresql_cluster': pgcluster['id'],
                     'database_name': db,
                     'shards': {

--- a/zmon_agent/main.py
+++ b/zmon_agent/main.py
@@ -18,6 +18,7 @@ BUILTIN_DISCOVERY = ('kubernetes',)
 
 AGENT_TYPE = 'zmon-agent'
 
+logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
To have a better point of contact for directing ZMON queries to replicas. Also exposing the expected and actual replica counts for better monitoring.