### PR TITLE
Find the postgresqls CRD to determine if API endpoint is available

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -61,16 +61,24 @@ class PostgreSQL(pykube.objects.NamespacedAPIObject):
     kind = "postgresql"
 
 
+class CustomResourceDefinition(pykube.objects.APIObject):
+    version = "apiextensions.k8s.io/v1beta1"
+    endpoint = "customresourcedefinitions"
+    kind = "CustomResourceDefinition"
+
+
 class PostgreSQLClient(kube.Client):
     def __init__(self, config_file_path=None, service_acc_path=kube.DEFAULT_SERVICE_ACC):
         super().__init__(config_file_path, service_acc_path)
-        self.is_operator_present = True
+        self.is_operator_present = False
+
+        for crd in CustomResourceDefinition.objects(self.client):
+            if str(crd) == 'postgresqls.acid.zalan.do':
+                self.is_operator_present = True
 
     def get_postgresqls(self, namespace=kube.DEFAULT_NAMESPACE) -> pykube.query.Query:
-        try:
+        if self.is_operator_present:
             return PostgreSQL.objects(self.client).filter(namespace=namespace)
-        except HTTPError:  # if the operator is not deployed, this happens
-            self.is_operator_present = False
 
 
 class Discovery:

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -11,8 +11,6 @@ import pykube
 
 import psycopg2
 
-from requests.exceptions import HTTPError
-
 from opentracing.ext import tags as ot_tags
 
 from opentracing_utils import trace, extract_span_from_kwargs, remove_span_from_kwargs


### PR DESCRIPTION
Catching the HTTPError as tried previously does not work because lazyness.  Here we go and explicitly look for the CRD, which implies the existence of the API endpoint.