### PR TITLE
Fix apt-get syntax in delivery.yaml

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -5,7 +5,7 @@ pipeline:
     commands:
       - desc: "Install dependencies"
         cmd: |
-          apt-get update \
+          apt-get update
           apt-get install -q -y --no-install-recommends \
             git \
             python3.5 \


### PR DESCRIPTION
Should be a separate command.  Sorry.