### PR TITLE
Pods/containers: expose resource requests & limits

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -17,6 +17,7 @@ from opentracing_utils import trace, extract_span_from_kwargs, remove_span_from_
 
 from . import kube
 from . import volumes
+from . import kube_resources
 
 
 AGENT_TYPE = 'zmon-kubernetes-agent'
@@ -220,6 +221,16 @@ def get_all(kube_client, kube_func, namespace=None, **kwargs) -> list:
     return items
 
 
+def parse_resources(resources):
+    result = {}
+    for resource_group in ('requests', 'limits'):
+        raw_resources = resources.get(resource_group)
+        if raw_resources:
+            converted = {name: kube_resources.parse_resource(value) for name, value in raw_resources.items()}
+            result[resource_group] = converted
+    return result
+
+
 def entity_labels(obj: dict, *sources: str) -> dict:
     result = {}
 
@@ -299,6 +310,7 @@ def get_cluster_pods_and_containers(
             container_ready = container_statuses.get(container['name'], {}).get('ready', False)
             container_restarts = container_statuses.get(container['name'], {}).get('restartCount', 0)
             container_ports = [p['containerPort'] for p in container.get('ports', []) if 'containerPort' in p]
+            container_resources = parse_resources(container.get('resources', {}))
 
             container_entity = {
                 'id': 'container-{}-{}-{}[{}]'.format(pod.name, pod.namespace, container_name, cluster_id),
@@ -307,13 +319,15 @@ def get_cluster_pods_and_containers(
                 'container_image': container_image,
                 'container_ready': container_ready,
                 'container_restarts': container_restarts,
-                'container_ports': container_ports
+                'container_ports': container_ports,
+                'resources': container_resources
             }
             pod_entity['containers'][container_name] = {
                 'image': container_image,
                 'ready': container_ready,
                 'restarts': container_restarts,
-                'ports': container_ports
+                'ports': container_ports,
+                'resources': container_resources
             }
 
             container_entity.update(pod_labels)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -310,7 +310,11 @@ def get_cluster_pods_and_containers(
             container_ready = container_statuses.get(container['name'], {}).get('ready', False)
             container_restarts = container_statuses.get(container['name'], {}).get('restartCount', 0)
             container_ports = [p['containerPort'] for p in container.get('ports', []) if 'containerPort' in p]
-            container_resources = parse_resources(container.get('resources', {}))
+
+            try:
+                container_resources = parse_resources(container.get('resources', {}))
+            except Exception:
+                container_resources = None
 
             container_entity = {
                 'id': 'container-{}-{}-{}[{}]'.format(pod.name, pod.namespace, container_name, cluster_id),

--- a/zmon_agent/discovery/kubernetes/kube_resources.py
+++ b/zmon_agent/discovery/kubernetes/kube_resources.py
@@ -1,0 +1,81 @@
+"""
+Helper functions for dealing with Kubernetes resource requests & limits
+"""
+import re
+
+_UNITS = {
+    'm': 0.001,
+    'K': 1000,
+    'M': 1000**2,
+    'G': 1000**3,
+    'T': 1000**4,
+    'P': 1000**5,
+    'E': 1000**6,
+    'Ki': 1024,
+    'Mi': 1024**2,
+    'Gi': 1024**3,
+    'Ti': 1024**4,
+    'Pi': 1024**5,
+    'Ei': 1024**6
+}
+
+_RESOURCE_REGEX = re.compile(r"""(?P<resource>\d+)(?P<unit>\w+)?""")
+
+
+def parse_resource(resource):
+    """Parse a Kubernetes resource definition into a raw float value.
+
+    >>> parse_resource("3")
+    3.0
+
+    >>> parse_resource("30m")
+    0.03
+
+    >>> parse_resource("3K")
+    3000.0
+
+    >>> parse_resource("3M")
+    3000000.0
+
+    >>> parse_resource("3G")
+    3000000000.0
+
+    >>> parse_resource("3T")
+    3000000000000.0
+
+    >>> parse_resource("3P")
+    3000000000000000.0
+
+    >>> parse_resource("3E")
+    3e+18
+
+    >>> parse_resource("3Ki")
+    3072.0
+
+    >>> parse_resource("3Mi")
+    3145728.0
+
+    >>> parse_resource("3Gi")
+    3221225472.0
+
+    >>> parse_resource("3Ti")
+    3298534883328.0
+
+    >>> parse_resource("3Pi")
+    3377699720527872.0
+
+    >>> parse_resource("3Ei")
+    3.458764513820541e+18
+
+    >>> parse_resource("invalid")
+    Traceback (most recent call last):
+        ...
+    ValueError: Invalid resource definition: invalid
+    """
+    match = re.match(_RESOURCE_REGEX, resource)
+    if not match:
+        raise ValueError("Invalid resource definition: " + resource)
+    resource = float(match.group('resource'))
+    unit_name = match.group('unit')
+    unit = _UNITS[unit_name] if unit_name else 1
+    return resource * unit

--- a/zmon_agent/discovery/kubernetes/kube_resources.py
+++ b/zmon_agent/discovery/kubernetes/kube_resources.py
@@ -75,7 +75,8 @@ def parse_resource(resource):
     match = re.match(_RESOURCE_REGEX, resource)
     if not match:
         raise ValueError("Invalid resource definition: " + resource)
-    resource = float(match.group('resource'))
+
+    value = float(match.group('resource'))
     unit_name = match.group('unit')
     unit = _UNITS[unit_name] if unit_name else 1
-    return resource * unit
+    return value * unit


### PR DESCRIPTION
Expose container resource requests & limits on both `kube_pod_container` and `kube_pod` entities. This will allow us to more easily find problematic deployments.