### PR TITLE
Add kube_deployment entities

### DIFF
--- a/zmon_agent/discovery/kubernetes/kube.py
+++ b/zmon_agent/discovery/kubernetes/kube.py
@@ -67,6 +67,9 @@ class Client:
     def get_daemonsets(self, namespace=DEFAULT_NAMESPACE) -> pykube.query.Query:
         return pykube.DaemonSet.objects(self.client).filter(namespace=namespace)
 
+    def get_deployments(self, namespace=DEFAULT_NAMESPACE) -> pykube.query.Query:
+        return pykube.Deployment.objects(self.client).filter(namespace=namespace)
+
     def get_replicasets(self, namespace=DEFAULT_NAMESPACE) -> pykube.query.Query:
         return pykube.ReplicaSet.objects(self.client).filter(namespace=namespace)
 


### PR DESCRIPTION
For some reason we don't have entities for deployments, only for replicasets.