### PR TITLE
Ignore HPA annotations

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -55,7 +55,8 @@ PROTECTED_FIELDS = {'id', 'type', 'infrastructure_account', 'created_by', 'regio
 
 SERVICE_ACCOUNT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'
 
-SKIPPED_ANNOTATIONS = {'kubernetes.io/created-by'}
+SKIPPED_ANNOTATIONS = {'kubernetes.io/created-by', 'autoscaling.alpha.kubernetes.io/current-metrics',
+                       'autoscaling.alpha.kubernetes.io/metrics', 'autoscaling.alpha.kubernetes.io/conditions'}
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))


### PR DESCRIPTION
No idea why `conditions` even exists as an annotation (instead of proper conditions), `metrics` is internal book-keeping.