### PR TITLE
Cronjobs: add status.lastScheduleTime

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -866,6 +866,7 @@ def get_cluster_cronjobs(kube_client, cluster_id, alias, environment, region, in
             'schedule': obj['spec'].get('schedule'),
             'successfulJobsHistoryLimit': obj['spec'].get('successfulJobsHistoryLimit'),
             'suspend': obj['spec'].get('suspend'),
+            'last_schedule_time': obj.get('status', {}).get('lastScheduleTime'),
 
             'active_jobs': [j.get('name') for j in obj['status'].get('active', [])]
         }


### PR DESCRIPTION
This is important to monitor because of that stupid Kubernetes bug (https://github.com/kubernetes/kubernetes/issues/42649).