### PR TITLE
Invalidate namespace cache before PG discovery

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -202,6 +202,8 @@ class Discovery:
             self.region, self.infrastructure_account, namespace=self.namespace
         )
 
+        self.pg_client.invalidate_namespace_cache()
+
         postgresql_entities = []
         postgresql_cluster_entities = []
         postgresql_cluster_member_entities = []


### PR DESCRIPTION
In order to pick up newly created namespaces (and the objects in it)