### PR TITLE
Exclude headless services from PG cluster discovery

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -962,8 +962,10 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
         labels = obj['metadata'].get('labels', {})
         version = labels.get('version', '')
 
-        # we skip non-Spilos and replica services
-        if labels.get('application') != 'spilo' or labels.get('spilo-role') == 'replica':
+        # we skip non-Spilos and replica services and headless services (-config)
+        if labels.get('application') != 'spilo' or \
+           labels.get('spilo-role') == 'replica' or \
+           obj['spec']['type'] == 'ClusterIP':
             continue
 
         service_namespace = obj['metadata']['namespace']

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -962,10 +962,8 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
         labels = obj['metadata'].get('labels', {})
         version = labels.get('version', '')
 
-        # we skip non-Spilos and replica services and headless services (-config)
-        if labels.get('application') != 'spilo' or \
-           labels.get('spilo-role') == 'replica' or \
-           obj['spec']['type'] == 'ClusterIP':
+        # we skip non-Spilos and replica services and headless services (-config, don't have a spilo_role)
+        if labels.get('application') != 'spilo' or labels.get('spilo-role') != 'master':
             continue
 
         service_namespace = obj['metadata']['namespace']


### PR DESCRIPTION
With a recent change in Patroni (https://github.com/zalando/patroni/pull/958), headless services were introduced.  These result in bogus postgresql-cluster entities and, consequently, agent errors about database discovery.  By this change, we exclude the non-LB type SVCs from the discovery.