### PR TITLE
Add namespace and team_id to all postgres related entities

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -955,7 +955,6 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
     current_span = extract_span_from_kwargs(**kwargs)
 
     ssets = [ss for ss in statefulsets if 'version' in ss]
-    pgs = list(postgresqls)
 
     services = get_all(kube_client, kube_client.get_services, namespace, span=current_span)
 
@@ -981,7 +980,7 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
         else:
             ss = statefulset[0]
 
-        postgresql = [pg for pg in pgs if pg['name'] == version and pg['namespace'] == service_namespace]
+        postgresql = [pg for pg in postgresqls if pg['name'] == version and pg['namespace'] == service_namespace]
 
         pg = {}
         if postgresql:
@@ -1011,7 +1010,8 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
             'deeplink2': '{}/#/clusters/{}/{}'.format(hosted_zone.format('pgview', alias), service_namespace, version),
             'icon2': 'fa-line-chart',
             'uid': pg.get('uid', ''),
-            'namespace': service_namespace
+            'namespace': service_namespace,
+            'team_id': pg.get('team_id', '')
         }
 
         entities.append(entity)
@@ -1082,7 +1082,9 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
             'icon1': 'fa-server',
             'deeplink2': '{}/#/clusters/{}/{}/{}'.format(hosted_zone.format('pgview', alias), pod_namespace,
                                                          cluster_name, pod.name),
-            'icon2': 'fa-line-chart'
+            'icon2': 'fa-line-chart',
+            'namespace': pod_namespace,
+            'team_id': labels.get('team')
         }
 
         entities.append(entity)
@@ -1121,7 +1123,8 @@ def get_postgresql_databases(cluster_id, alias, environment, region, infrastruct
                     db: '{}:{}/{}'.format(pgcluster['dnsname'], POSTGRESQL_DEFAULT_PORT, db)
                 },
                 'role': 'master',
-                'namespace': pgcluster.get('namespace')
+                'namespace': pgcluster.get('namespace'),
+                'team_id': pgcluster.get('team_id')
             }
 
             entities.append(entity)
@@ -1145,7 +1148,8 @@ def get_postgresql_databases(cluster_id, alias, environment, region, infrastruct
                         db: '{}:{}/{}'.format(repl_dnsname, POSTGRESQL_DEFAULT_PORT, db)
                     },
                     'role': 'replica',
-                    'namespace': pgcluster.get('namespace')
+                    'namespace': pgcluster.get('namespace'),
+                    'team_id': pgcluster.get('team_id')
                 }
 
                 entities.append(replicatype_entity)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -940,7 +940,8 @@ def get_postgresqls(pg_client, cluster_id, alias, environment, region, infrastru
             'team_id': metadata.get('labels', {}).get('team', ''),
             'uid': metadata.get('uid'),
             'expected_instance_count': pg.get('spec', {}).get('numberOfInstances'),
-            'namespace': metadata.get('namespace', '')
+            'namespace': metadata.get('namespace', ''),
+            'postgresql_version': pg.get('spec', {}).get('postgresql', {}).get('version')
         }
 
         entities.append(entity)
@@ -1011,7 +1012,8 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
             'icon2': 'fa-line-chart',
             'uid': pg.get('uid', ''),
             'namespace': service_namespace,
-            'team_id': pg.get('team_id', '')
+            'team_id': pg.get('team_id', ''),
+            'postgresql_version': pg.get('postgresql_version')
         }
 
         entities.append(entity)


### PR DESCRIPTION
In many cases either one or both of these were missing, causing confusion in rare cases (where names otherwise would clash, for example, especially with the database entities).