### PR TITLE
Add Kubernetes AWSIAMRole entity types

### DIFF
--- a/zmon_agent/discovery/kubernetes/crds.py
+++ b/zmon_agent/discovery/kubernetes/crds.py
@@ -5,3 +5,9 @@ class PlatformCredentialSet(NamespacedAPIObject):
     version = 'zalando.org/v1'
     endpoint = 'platformcredentialssets'
     kind = 'PlatformCredentialSet'
+
+
+class AWSIAMRole(NamespacedAPIObject):
+    version = 'zalando.org/v1'
+    endpoint = 'awsiamroles'
+    kind = 'AWSIAMRole'

--- a/zmon_agent/discovery/kubernetes/kube.py
+++ b/zmon_agent/discovery/kubernetes/kube.py
@@ -3,7 +3,10 @@ Wrapper client for Kubernetes API using ``pykube``
 """
 import pykube
 
-from zmon_agent.discovery.kubernetes.crds import PlatformCredentialSet
+from zmon_agent.discovery.kubernetes.crds import (
+    PlatformCredentialSet,
+    AWSIAMRole,
+)
 
 DEFAULT_SERVICE_ACC = '/var/run/secrets/kubernetes.io/serviceaccount'
 
@@ -100,3 +103,6 @@ class Client:
 
     def get_platformcredentialsets(self, namespace=DEFAULT_NAMESPACE) -> pykube.query.Query:
         return PlatformCredentialSet.objects(self.client).filter(namespace=namespace)
+
+    def get_awsiamroles(self, namespace=DEFAULT_NAMESPACE) -> pykube.query.Query:
+        return AWSIAMRole.objects(self.client).filter(namespace=namespace)


### PR DESCRIPTION
This enables discovery of `AWSIAMRole` CRDs used for providing AWS IAM
Roles to pods in a more robust way.

We are rolling out https://github.com/mikkeloscar/kube-aws-iam-controller which uses these CRDs to provide AWS IAM credentials to pods and would like to monitor these resources.