### PR TITLE
Make status field access more robust for Platform Credentials Sets

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1233,9 +1233,9 @@ def get_cluster_credential_sets(kube_client, cluster_id, alias, environment, reg
             'region': region,
             'pcs_name': cs.name,
             'pcs_namespace': obj['metadata']['namespace'],
-            'errors': obj['status']['errors'],
-            'problems': obj['status']['problems'],
-            'tokens': obj['status'].get('tokens', {})
+            'errors': obj.get('status', {}).get('errors', []),
+            'problems': obj.get('status', {}).get('problems', []),
+            'tokens': obj.get('status', {}).get('tokens', {})
         }
         entity.update(entity_labels(obj, 'labels', 'annotations'))
         entities.append(entity)


### PR DESCRIPTION
In case the status field is not created on a platformcredentialsset resource the agent would get an exception and not collect updates for all entities.

This makes the discovery more safe by handling cases where some of the data is missing.

For PlatformCredentialsSets the data can be missing if the content of the resource is invalid.