### PR TITLE
Add time and patroni state

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1142,7 +1142,9 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
                                                          cluster_name, pod.name),
             'icon2': 'fa-line-chart',
             'namespace': pod_namespace,
-            'team_id': labels.get('team')
+            'team_id': labels.get('team'),
+            'start_time': obj.get('status', {}).get('startTime', ''),
+            'patroni_state': json.loads(obj['metadata']['annotations']['status'])["state"]
         }
 
         entities.append(entity)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1142,9 +1142,7 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
                                                          cluster_name, pod.name),
             'icon2': 'fa-line-chart',
             'namespace': pod_namespace,
-            'team_id': labels.get('team'),
-            'start_time': obj.get('status', {}).get('startTime', ''),
-            'patroni_state': obj['metadata'].get('annotations', {}).get('status').partition('state')[2].partition(':')[2].partition(',')[0]
+            'team_id': labels.get('team')
         }
 
         entities.append(entity)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1144,7 +1144,7 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
             'namespace': pod_namespace,
             'team_id': labels.get('team'),
             'start_time': obj.get('status', {}).get('startTime', ''),
-            'patroni_state': json.loads(obj['metadata']['annotations']['status'])["state"]
+            'patroni_state': json.loads(obj.get('metadata', {}).get('annotations', {}).get('status', {}))["state"]
         }
 
         entities.append(entity)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1145,7 +1145,8 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
             'namespace': pod_namespace,
             'team_id': labels.get('team'),
             'pod_start_time': obj.get('status', {}).get('startTime', ''),
-            'patroni_state': json.loads(obj.get("metadata", {}).get("annotations", {}).get("status", {})).get("state", {})
+            'patroni_state': json.loads(obj.get("metadata", {}).get("annotations", {}).get("status", {}))
+                             .get("state", {})
         }
 
         entities.append(entity)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1142,7 +1142,9 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
                                                          cluster_name, pod.name),
             'icon2': 'fa-line-chart',
             'namespace': pod_namespace,
-            'team_id': labels.get('team')
+            'team_id': labels.get('team'),
+            'start_time': obj.get('status', {}).get('startTime', ''),
+            'patroni_state': obj['metadata'].get('annotations', {}).get('status').partition('state')[2].partition(':')[2].partition(',')[0]
         }
 
         entities.append(entity)

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -996,7 +996,8 @@ def get_postgresqls(pg_client, cluster_id, alias, environment, region, infrastru
             'expected_instance_count': spec.get('numberOfInstances'),
             'namespace': metadata.get('namespace', ''),
             'spec': spec,
-            'postgresql_version': spec.get('postgresql', {}).get('version')
+            'postgresql_version': spec.get('postgresql', {}).get('version'),
+            'pg_start_time': metadata.get('creationTimestamp')
         }
 
         entities.append(entity)
@@ -1143,8 +1144,8 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
             'icon2': 'fa-line-chart',
             'namespace': pod_namespace,
             'team_id': labels.get('team'),
-            'start_time': obj.get('status', {}).get('startTime', ''),
-            'patroni_state': json.loads(obj.get('metadata', {}).get('annotations', {}).get('status', {}))["state"]
+            'pod_start_time': obj.get('status', {}).get('startTime', ''),
+            'patroni_state': json.loads(obj.get("metadata", {}).get("annotations", {}).get("status", {})).get("state", {})
         }
 
         entities.append(entity)


### PR DESCRIPTION
For better monitoring of postgresql clusters it is required to have the start time of pods and patroni state, hence the PR