### PR TITLE
Add created_by and other fields to postgresqls

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1005,7 +1005,10 @@ def get_postgresqls(pg_client, cluster_id, alias, environment, region, infrastru
             'namespace': metadata.get('namespace', ''),
             'spec': spec,
             'postgresql_version': spec.get('postgresql', {}).get('version'),
-            'pg_start_time': metadata.get('creationTimestamp')
+            'pg_start_time': metadata.get('creationTimestamp'),
+            'created_by': AGENT_TYPE,
+            'infrastructure_account': infrastructure_account,
+            'account_alias': alias
         }
 
         entities.append(entity)

--- a/zmon_agent/main.py
+++ b/zmon_agent/main.py
@@ -23,8 +23,6 @@ from zmon_agent.discovery.kubernetes import get_discovery_agent_class
 
 BUILTIN_DISCOVERY = ('kubernetes',)
 
-AGENT_TYPE = 'zmon-agent'
-
 logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))


### PR DESCRIPTION
In the current state, old entities of type `postgresql` are not cleaned up.

Added two more 'infrastructural' fields to the type, too.