### PR TITLE
Exclude pods in non running phase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 opentracing
 opentracing-utils
-psycopg2
+psycopg2-binary
 pykube>=0.15.0
 requests>=2.12
 scm-source>=1.0.9

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1104,7 +1104,8 @@ def get_postgresql_cluster_members(kube_client, cluster_id, alias, environment, 
 
         # TODO: filter in the API call
         labels = obj['metadata'].get('labels', {})
-        if labels.get('application') != 'spilo' or labels.get('version') is None:
+        pod_phase = obj['status']['phase']
+        if labels.get('application') != 'spilo' or labels.get('version') is None or pod_phase != 'Running':
             continue
 
         pod_number = pod.name.split('-')[-1]


### PR DESCRIPTION
This caused all Postgres related entities to disappear, due to an error:

```2019-10-23 10:51:09,782 ERROR: Failed postgresql discovery!
Traceback (most recent call last):
  File "/home/avaczi/GH/zmon-agent-core/zmon_agent/discovery/kubernetes/cluster.py", line 234, in get_entities
    self.infrastructure_account, self.hosted_zone_format_string, namespace=self.namespace)
  File "/home/avaczi/.local/lib/python3.6/site-packages/opentracing_utils/decorators.py", line 69, in wrapper
    return f(*args, **kwargs)
  File "/home/avaczi/GH/zmon-agent-core/zmon_agent/discovery/kubernetes/cluster.py", line 1159, in get_postgresql_cluster_members
    'patroni_state': json.loads(obj.get("metadata", {}).get("annotations", {}).get("status", {}))
  File "/usr/lib/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'dict'
```

Also, switching to `psycopg2-binary` package (reasoning: http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/)
