### PR TITLE
Add patroni status and history to kube_service

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -422,7 +422,8 @@ def get_cluster_services(
     endpoints = get_all(kube_client, kube_client.get_endpoints, namespace, span=current_span)
     # number of endpoints per service
     endpoints_map = {e.name: len(e.obj['subsets']) for e in endpoints if e.obj.get('subsets')}
-    config_endpoints_map = {e.name: e.obj['metadata'].get('annotations', {}) for e in endpoints if e.name.endswith('-config')}
+    config_endpoints_map = {e.name: e.obj['metadata'].get('annotations', {}) for e in endpoints
+                            if e.name.endswith('-config')}
 
     services = get_all(kube_client, kube_client.get_services, namespace, span=current_span)
 
@@ -472,7 +473,7 @@ def get_cluster_services(
             'initialize_key': config_endpoints_map.get(service.name, {}).get('initialize', {}),
             'pg_status': status,
             'patroni_history': list(reversed(list(json.loads(str(config_endpoints_map.get(service.name, {})
-                                .get('history', {}))))))[0:10] # Get only last 10 events from the history
+                                    .get('history', {}))))))[0:10]  # Get only last 10 events from the history
         }
 
         entity.update(entity_labels(obj, 'labels', 'annotations'))

--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -1092,7 +1092,7 @@ def get_postgresql_clusters(kube_client, cluster_id, alias, environment, region,
             'team_id': pg.get('team_id', ''),
             'postgresql_version': pg.get('postgresql_version'),
             'cluster_status': status,
-            'patroni_history': history[-10:]  # Get latest 10 events from the history
+            'cluster_history': history[-10:]  # Get latest 10 events from the history
         }
 
         entities.append(entity)


### PR DESCRIPTION
To enhance the monitoring of postgresql clusters, the initialize key
from the config based on that is added to kube_service. Also, the
history of failovers/switchovers is also added for more detailed
monitoring.