### PR TITLE
kube_node: add provider_id

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -528,6 +528,7 @@ def get_cluster_nodes(
             'infrastructure_account': infrastructure_account,
             'region': region,
 
+            'provider_id': obj['spec'].get('providerID'),
             'ip': ip,
             'host': host,
             'external_ip': addresses.get('ExternalIP', ''),


### PR DESCRIPTION
Some of the data is only available at `type: instance` entities, and without this it's impossible to correlate.