### PR TITLE
Mark more fields as protected

### DIFF
--- a/zmon_agent/discovery/kubernetes/cluster.py
+++ b/zmon_agent/discovery/kubernetes/cluster.py
@@ -53,7 +53,8 @@ AWSIAMROLE_TYPE = 'kube_awsiamrole'
 
 INSTANCE_TYPE_LABEL = 'beta.kubernetes.io/instance-type'
 
-PROTECTED_FIELDS = {'id', 'type', 'infrastructure_account', 'created_by', 'region', 'team'}
+PROTECTED_FIELDS = {'id', 'type', 'kube_cluster', 'alias', 'environment', 'created_by',
+                    'infrastructure_account', 'region', 'name', 'namespace'}
 
 SERVICE_ACCOUNT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'
 


### PR DESCRIPTION
Users shouldn't be able to overwrite `environment` or `kube_cluster`. We should've made it impossible for labels/annotations to overwrite built-in fields by using keys like `label_foo` instead of `foo`, but I don't think we'll be able to migrate checks/alerts successfully now.