### PR TITLE
Change kube library to pykube-ng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install tox tox-travis
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 opentracing
 opentracing-utils
 psycopg2-binary
-pykube>=0.15.0
+pykube-ng==20.1.0
 requests>=2.12
 scm-source>=1.0.9
 stups-tokens>=1.0.18


### PR DESCRIPTION
This changes the Kubernetes library to https://github.com/hjacobs/pykube which is a fork and updated version of the abandoned https://github.com/kelproject/pykube library.

This change is needed in order to work with Kubernetes v1.16 which doesn't support the `extensions/v1beta1` APIs for deployments.